### PR TITLE
Make disablehideAtCopy relying on TCA config more obvious

### DIFF
--- a/Documentation/PageTsconfig/TCEmain/Index.rst
+++ b/Documentation/PageTsconfig/TCEmain/Index.rst
@@ -434,8 +434,8 @@ disableHideAtCopy
          boolean
 
    Description
-         Disables the "hideAtCopy" feature (if configured for the table in
-         :code:`$GLOBALS['TCA']`).
+         Disables the "hideAtCopy" feature. This feature needs to be activated for the table in
+         :code:`$GLOBALS['TCA']`)!
 
          For an example, see :ref:`disablePrependAtCopy <pagetcemaintables-disableprependatcopy>`
          above.


### PR DESCRIPTION
It seems quite some people - me included - do easily oversee the TCA configuration - http://www.typo3forum.net/discussion/50841/tt-news-kopie-von-news-standartmaessig-verbergen
Can it be made more obvious? Is it possible to link the TCA documentation?
